### PR TITLE
Set up Compose navigation with placeholder screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)

--- a/app/src/main/java/com/example/stockcount/MainActivity.kt
+++ b/app/src/main/java/com/example/stockcount/MainActivity.kt
@@ -4,14 +4,29 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.example.stockcount.ui.theme.StockCountTheme
+
+sealed class Screen(val route: String) {
+    object Home : Screen("home")
+    object Scan : Screen("scan")
+    object List : Screen("list")
+    object Detail : Screen("detail")
+    object Export : Screen("export")
+}
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,11 +34,16 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             StockCountTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = Screen.Home.route
+                ) {
+                    composable(Screen.Home.route) { HomeScreen(navController) }
+                    composable(Screen.Scan.route) { ScanScreen(navController) }
+                    composable(Screen.List.route) { ListScreen(navController) }
+                    composable(Screen.Detail.route) { DetailScreen(navController) }
+                    composable(Screen.Export.route) { ExportScreen(navController) }
                 }
             }
         }
@@ -31,17 +51,69 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
+fun HomeScreen(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text("Home Screen")
+        Button(onClick = { navController.navigate(Screen.Scan.route) }) {
+            Text("Go to Scan")
+        }
+        Button(onClick = { navController.navigate(Screen.List.route) }) {
+            Text("Go to List")
+        }
+        Button(onClick = { navController.navigate(Screen.Detail.route) }) {
+            Text("Go to Detail")
+        }
+        Button(onClick = { navController.navigate(Screen.Export.route) }) {
+            Text("Go to Export")
+        }
+    }
+}
+
+@Composable
+fun ScanScreen(navController: NavController) {
+    PlaceholderScreen("Scan Screen", navController)
+}
+
+@Composable
+fun ListScreen(navController: NavController) {
+    PlaceholderScreen("List Screen", navController)
+}
+
+@Composable
+fun DetailScreen(navController: NavController) {
+    PlaceholderScreen("Detail Screen", navController)
+}
+
+@Composable
+fun ExportScreen(navController: NavController) {
+    PlaceholderScreen("Export Screen", navController)
+}
+
+@Composable
+private fun PlaceholderScreen(title: String, navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(title)
+        Button(onClick = { navController.popBackStack() }) {
+            Text("Back")
+        }
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun HomePreview() {
     StockCountTheme {
-        Greeting("Android")
+        HomeScreen(rememberNavController())
     }
 }
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+navigationCompose = "2.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -17,6 +18,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## Summary
- Configure MainActivity for Jetpack Compose navigation
- Add Navigation Compose dependency
- Provide placeholder Home, Scan, List, Detail, and Export composables

## Testing
- `bash gradlew build` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0363de84832983e6e2ff094dc907