### PR TITLE
Add DataStore settings and scan undo buffer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/stockcount/MainActivity.kt
+++ b/app/src/main/java/com/example/stockcount/MainActivity.kt
@@ -12,8 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.stockcount.ui.theme.StockCountTheme
+import com.example.stockcount.data.SettingsDataStore
+import com.example.stockcount.data.ScanBuffer
 
 class MainActivity : ComponentActivity() {
+    private val settings by lazy { SettingsDataStore(this) }
+    private val scanBuffer = ScanBuffer()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()

--- a/app/src/main/java/com/example/stockcount/data/ScanBuffer.kt
+++ b/app/src/main/java/com/example/stockcount/data/ScanBuffer.kt
@@ -1,0 +1,46 @@
+package com.example.stockcount.data
+
+/**
+ * In-memory buffer that stores the most recent scan. The buffer allows undoing the
+ * last scan within a configurable time window. Once the window has passed, the
+ * scan can no longer be undone.
+ */
+class ScanBuffer(private val windowMillis: Long = DEFAULT_WINDOW_MS) {
+
+    private var lastScan: Scan? = null
+
+    /**
+     * Records a scan with the current time.
+     */
+    fun record(code: String, timeMillis: Long = System.currentTimeMillis()) {
+        lastScan = Scan(code, timeMillis)
+    }
+
+    /**
+     * Returns true if the last scan is still within the undo window.
+     */
+    fun canUndo(currentTimeMillis: Long = System.currentTimeMillis()): Boolean {
+        val scan = lastScan ?: return false
+        return currentTimeMillis - scan.timestamp <= windowMillis
+    }
+
+    /**
+     * Returns the last scanned code if undo is allowed. The scan is cleared once
+     * undone. If the window has expired or no scan exists, returns null.
+     */
+    fun undo(currentTimeMillis: Long = System.currentTimeMillis()): String? {
+        return if (canUndo(currentTimeMillis)) {
+            val code = lastScan!!.code
+            lastScan = null
+            code
+        } else {
+            null
+        }
+    }
+
+    private data class Scan(val code: String, val timestamp: Long)
+
+    companion object {
+        const val DEFAULT_WINDOW_MS: Long = 5_000L
+    }
+}

--- a/app/src/main/java/com/example/stockcount/data/SettingsDataStore.kt
+++ b/app/src/main/java/com/example/stockcount/data/SettingsDataStore.kt
@@ -1,0 +1,42 @@
+package com.example.stockcount.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val DATA_STORE_NAME = "settings"
+
+val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_STORE_NAME)
+
+class SettingsDataStore(private val context: Context) {
+
+    companion object {
+        val VIBRATION_ENABLED = booleanPreferencesKey("vibration_enabled")
+        val FLASHLIGHT_ENABLED = booleanPreferencesKey("flashlight_enabled")
+    }
+
+    val vibrationEnabled: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->
+        preferences[VIBRATION_ENABLED] ?: true
+    }
+
+    val flashlightEnabled: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->
+        preferences[FLASHLIGHT_ENABLED] ?: false
+    }
+
+    suspend fun setVibrationEnabled(enabled: Boolean) {
+        context.settingsDataStore.edit { preferences ->
+            preferences[VIBRATION_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setFlashlightEnabled(enabled: Boolean) {
+        context.settingsDataStore.edit { preferences ->
+            preferences[FLASHLIGHT_ENABLED] = enabled
+        }
+    }
+}

--- a/app/src/test/java/com/example/stockcount/data/ScanBufferTest.kt
+++ b/app/src/test/java/com/example/stockcount/data/ScanBufferTest.kt
@@ -1,0 +1,28 @@
+package com.example.stockcount.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScanBufferTest {
+
+    @Test
+    fun undoWithinWindowReturnsCode() {
+        val buffer = ScanBuffer(windowMillis = 1_000L)
+        buffer.record("123", timeMillis = 0L)
+
+        val result = buffer.undo(currentTimeMillis = 500L)
+
+        assertEquals("123", result)
+    }
+
+    @Test
+    fun undoAfterWindowReturnsNull() {
+        val buffer = ScanBuffer(windowMillis = 1_000L)
+        buffer.record("123", timeMillis = 0L)
+
+        val result = buffer.undo(currentTimeMillis = 1_500L)
+
+        assertNull(result)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Add `SettingsDataStore` to persist vibration and flashlight options
- Provide `ScanBuffer` utility supporting time-limited undo of last scan
- Add unit tests for scan buffer and wire up dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba068dcf78832997c6cec566f9c787