### PR TITLE
Add CSV export via SAF with UTF-8 encoding

### DIFF
--- a/app/src/main/java/com/example/stockcount/ExportScreen.kt
+++ b/app/src/main/java/com/example/stockcount/ExportScreen.kt
@@ -1,0 +1,51 @@
+package com.example.stockcount
+
+import android.content.Context
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.stockcount.data.StockRepository
+import com.example.stockcount.export.CsvExporter
+
+/**
+ * Screen offering a button to export repository data as CSV using SAF.
+ */
+@Composable
+fun ExportScreen() {
+    val context = LocalContext.current
+    val items = remember { StockRepository.getItems() }
+    val csv = remember(items) { CsvExporter.export(items) }
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("text/csv")) { uri ->
+        uri?.let { saveCsv(context, it, csv) }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Button(onClick = { launcher.launch("stock.csv") }) {
+            Text("Export CSV")
+        }
+    }
+}
+
+private fun saveCsv(context: Context, uri: Uri, data: String) {
+    context.contentResolver.openOutputStream(uri)?.use { out ->
+        // Write BOM to hint Excel/Sheets at UTF-8 encoding
+        out.write("\uFEFF".toByteArray(Charsets.UTF_8))
+        out.write(data.toByteArray(Charsets.UTF_8))
+    }
+}

--- a/app/src/main/java/com/example/stockcount/MainActivity.kt
+++ b/app/src/main/java/com/example/stockcount/MainActivity.kt
@@ -4,13 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.example.stockcount.ui.theme.StockCountTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +12,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             StockCountTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                ExportScreen()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    StockCountTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/stockcount/data/StockItem.kt
+++ b/app/src/main/java/com/example/stockcount/data/StockItem.kt
@@ -1,0 +1,13 @@
+package com.example.stockcount.data
+
+/**
+ * Represents a single stock entry that can be exported to CSV.
+ */
+data class StockItem(
+    val ean: String,
+    val name: String,
+    val quantity: Int,
+    val location: String,
+    val note: String,
+    val updatedAt: String,
+)

--- a/app/src/main/java/com/example/stockcount/data/StockRepository.kt
+++ b/app/src/main/java/com/example/stockcount/data/StockRepository.kt
@@ -1,0 +1,25 @@
+package com.example.stockcount.data
+
+/**
+ * Simple in-memory repository providing sample data for export.
+ */
+object StockRepository {
+    fun getItems(): List<StockItem> = listOf(
+        StockItem(
+            ean = "1234567890123",
+            name = "Sample Item",
+            quantity = 10,
+            location = "Warehouse",
+            note = "",
+            updatedAt = "2024-01-01T00:00:00Z",
+        ),
+        StockItem(
+            ean = "9876543210987",
+            name = "Another Item",
+            quantity = 5,
+            location = "Storefront",
+            note = "Damaged box",
+            updatedAt = "2024-02-01T12:00:00Z",
+        ),
+    )
+}

--- a/app/src/main/java/com/example/stockcount/export/CsvExporter.kt
+++ b/app/src/main/java/com/example/stockcount/export/CsvExporter.kt
@@ -1,0 +1,37 @@
+package com.example.stockcount.export
+
+import com.example.stockcount.data.StockItem
+
+/**
+ * Builds a CSV representation of stock items using comma delimiters and UTF-8 encoding.
+ */
+object CsvExporter {
+    private val headers = listOf("ean", "name", "quantity", "location", "note", "updated_at")
+
+    fun export(items: List<StockItem>): String {
+        val sb = StringBuilder()
+        sb.append(headers.joinToString(",")).append('\n')
+        for (item in items) {
+            sb.append(
+                listOf(
+                    item.ean,
+                    item.name,
+                    item.quantity.toString(),
+                    item.location,
+                    item.note,
+                    item.updatedAt,
+                ).joinToString(",") { escape(it) }
+            ).append('\n')
+        }
+        return sb.toString()
+    }
+
+    private fun escape(value: String): String {
+        val needsQuotes = value.contains(',') || value.contains('\n') || value.contains('"')
+        var result = value.replace("\"", "\"\"")
+        if (needsQuotes) {
+            result = "\"$result\""
+        }
+        return result
+    }
+}

--- a/app/src/test/java/com/example/stockcount/export/CsvExporterTest.kt
+++ b/app/src/test/java/com/example/stockcount/export/CsvExporterTest.kt
@@ -1,0 +1,20 @@
+package com.example.stockcount.export
+
+import com.example.stockcount.data.StockItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CsvExporterTest {
+    @Test
+    fun `exports CSV with header and rows`() {
+        val items = listOf(
+            StockItem("1", "Name", 2, "Loc", "Note", "2024-01-01"),
+        )
+        val csv = CsvExporter.export(items)
+        val expected = "ean,name,quantity,location,note,updated_at\n1,Name,2,Loc,Note,2024-01-01\n"
+        assertEquals(expected, csv)
+        // Verify UTF-8 encoding
+        val bytes = csv.toByteArray(Charsets.UTF_8)
+        assertEquals(csv, String(bytes, Charsets.UTF_8))
+    }
+}


### PR DESCRIPTION
## Summary
- add `StockItem` model and repository with sample data
- implement `CsvExporter` to generate comma-delimited UTF-8 CSV
- add Compose screen using SAF to save CSV and integrate into `MainActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba094bb9c48329928496f7ff14f80f